### PR TITLE
feat: Laravel認証システムとコードフォーマッター設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 /vendor
 .serena
 CLAUDE.md
+
+# Cookie test files
+cookies*.txt
+cookiejar
+
+# Code formatter cache
+laravel-api/.php-cs-fixer.cache
+*.cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       context: ./laravel-api
     container_name: devlogr-laravel
     ports:
-      - "8000:8000"
+      - "8000:80"
     depends_on:
       - mysql
     volumes:
@@ -42,6 +42,9 @@ services:
       DB_DATABASE: devlogr
       DB_USERNAME: devlogr
       DB_PASSWORD: secret
+      APP_URL: http://localhost:8000
+      SANCTUM_STATEFUL_DOMAINS: localhost:3000,localhost:8000
+      SESSION_DOMAIN: localhost
 
 volumes:
   mysql-data:

--- a/laravel-api/.editorconfig
+++ b/laravel-api/.editorconfig
@@ -16,3 +16,25 @@ indent_size = 2
 
 [docker-compose.yml]
 indent_size = 4
+
+[*.php]
+indent_size = 4
+indent_style = space
+
+[*.blade.php]
+indent_size = 4
+indent_style = space
+
+[*.{js,jsx,ts,tsx,vue}]
+indent_size = 2
+indent_style = space
+
+[*.{json,lock}]
+indent_size = 4
+indent_style = space
+
+[composer.json]
+indent_size = 4
+
+[package.json]
+indent_size = 2

--- a/laravel-api/.php-cs-fixer.php
+++ b/laravel-api/.php-cs-fixer.php
@@ -1,0 +1,159 @@
+<?php
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->in([
+        __DIR__ . '/app',
+        __DIR__ . '/config',
+        __DIR__ . '/database',
+        __DIR__ . '/routes',
+        __DIR__ . '/tests',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'binary_operator_spaces' => [
+            'default' => 'single_space',
+            'operators' => [
+                '=>' => 'align_single_space_minimal',
+                '=' => 'align_single_space_minimal',
+            ],
+        ],
+        'blank_line_after_namespace' => true,
+        'blank_line_after_opening_tag' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['return', 'throw', 'try'],
+        ],
+        'cast_spaces' => true,
+        'class_attributes_separation' => [
+            'elements' => [
+                'const' => 'one',
+                'method' => 'one',
+                'property' => 'one',
+            ],
+        ],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => true,
+        'function_typehint_space' => true,
+        'single_blank_line_before_namespace' => true,
+        'include' => true,
+        'increment_style' => ['style' => 'post'],
+        'lowercase_cast' => true,
+        'lowercase_keywords' => true,
+        'lowercase_static_reference' => true,
+        'magic_constant_casing' => true,
+        'magic_method_casing' => true,
+        'method_argument_space' => [
+            'on_multiline' => 'ensure_fully_multiline',
+            'keep_multiple_spaces_after_comma' => false,
+        ],
+        'native_function_casing' => true,
+        'native_function_type_declaration_casing' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_comment' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => [
+            'tokens' => [
+                'case',
+                'continue',
+                'curly_brace_block',
+                'default',
+                'extra',
+                'parenthesis_brace_block',
+                'square_brace_block',
+                'switch',
+                'throw',
+                'use',
+            ],
+        ],
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_mixed_echo_print' => true,
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+        ],
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => [
+            'statements' => ['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case', 'yield'],
+        ],
+        'no_unneeded_curly_braces' => true,
+        'no_unset_cast' => true,
+        'no_unused_imports' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'normalize_index_brace' => true,
+        'object_operator_without_whitespace' => true,
+        'ordered_imports' => [
+            'imports_order' => ['class', 'function', 'const'],
+            'sort_algorithm' => 'alpha',
+        ],
+        'php_unit_fqcn_annotation' => true,
+        'php_unit_method_casing' => ['case' => 'camel_case'],
+        'phpdoc_align' => [
+            'align' => 'vertical',
+            'tags' => ['param', 'property', 'property-read', 'property-write', 'return', 'throws', 'type', 'var'],
+        ],
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_indent' => true,
+        'phpdoc_inline_tag_normalizer' => true,
+        'phpdoc_no_access' => true,
+        'phpdoc_no_alias_tag' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_return_self_reference' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_separation' => true,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'none',
+        ],
+        'phpdoc_var_without_name' => true,
+        'return_type_declaration' => true,
+        'semicolon_after_instruction' => true,
+        'short_scalar_cast' => true,
+        'single_blank_line_at_eof' => true,
+        'single_class_element_per_statement' => true,
+        'single_import_per_statement' => true,
+        'single_line_after_imports' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        'single_line_throw' => false,
+        'single_quote' => true,
+        'single_trait_insert_per_statement' => true,
+        'space_after_semicolon' => [
+            'remove_in_empty_for_expressions' => true,
+        ],
+        'standardize_not_equals' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
+        'trim_array_spaces' => true,
+        'types_spaces' => true,
+        'unary_operator_spaces' => true,
+        'visibility_required' => ['elements' => ['const', 'method', 'property']],
+        'whitespace_after_comma_in_array' => true,
+        'yoda_style' => false,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder);

--- a/laravel-api/.prettierignore
+++ b/laravel-api/.prettierignore
@@ -1,0 +1,12 @@
+vendor/
+node_modules/
+bootstrap/cache/
+storage/
+public/build/
+public/hot/
+*.blade.php
+*.php
+composer.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml

--- a/laravel-api/.prettierrc
+++ b/laravel-api/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "trailingComma": "es5",
+    "printWidth": 100,
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "endOfLine": "lf"
+}

--- a/laravel-api/Dockerfile
+++ b/laravel-api/Dockerfile
@@ -1,16 +1,45 @@
 FROM php:8.3-apache
 
-# 必要拡張
+# 必要な拡張機能とツールをインストール
 RUN apt-get update && apt-get install -y \
-    git zip unzip curl libpng-dev libonig-dev libxml2-dev \
-    && docker-php-ext-install pdo_mysql
+    git \
+    zip \
+    unzip \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    && docker-php-ext-install pdo_mysql \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Composer install
+# Composerをインストール
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
-# Apache設定
+# Apacheの設定
+RUN a2enmod rewrite
+
+# Apache DocumentRootを設定
+RUN sed -i 's|DocumentRoot /var/www/html|DocumentRoot /var/www/html/public|g' /etc/apache2/sites-available/000-default.conf
+
+# Directoryディレクティブを追加
+RUN sed -i '/<\/VirtualHost>/i \
+    <Directory /var/www/html/public>\n\
+        Options Indexes FollowSymLinks\n\
+        AllowOverride All\n\
+        Require all granted\n\
+    </Directory>' /etc/apache2/sites-available/000-default.conf
+
+# 作業ディレクトリを設定
 WORKDIR /var/www/html
+
+# アプリケーションファイルをコピー（開発環境ではボリュームマウントで上書きされる）
 COPY . .
 
-# Laravel初期化（あとでbind mountされるのでOK）
-RUN chmod -R 755 storage
+# パーミッション設定
+RUN chown -R www-data:www-data /var/www/html \
+    && chmod -R 755 storage \
+    && chmod -R 755 bootstrap/cache
+
+# Apacheをフォアグラウンドで実行
+CMD ["apache2-foreground"]

--- a/laravel-api/app/Http/Controllers/Api/AuthController.php
+++ b/laravel-api/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (!Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $request->session()->regenerate();
+
+        return response()->json(Auth::user(), 200);
+    }
+
+    public function me(Request $request)
+    {
+        return response()->json($request->user());
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::guard('web')->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response()->json(['message' => 'Logged out']);
+    }
+}

--- a/laravel-api/app/Http/Controllers/Controller.php
+++ b/laravel-api/app/Http/Controllers/Controller.php
@@ -2,7 +2,4 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
-{
-    //
-}
+abstract class Controller {}

--- a/laravel-api/app/Models/User.php
+++ b/laravel-api/app/Models/User.php
@@ -10,7 +10,8 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/laravel-api/app/Providers/AppServiceProvider.php
+++ b/laravel-api/app/Providers/AppServiceProvider.php
@@ -9,16 +9,10 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Register any application services.
      */
-    public function register(): void
-    {
-        //
-    }
+    public function register(): void {}
 
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
-    {
-        //
-    }
+    public function boot(): void {}
 }

--- a/laravel-api/bootstrap/app.php
+++ b/laravel-api/bootstrap/app.php
@@ -6,13 +6,12 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
+        web: __DIR__ . '/../routes/web.php',
+        api: __DIR__ . '/../routes/api.php',
+        commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->statefulApi();
     })
-    ->withExceptions(function (Exceptions $exceptions): void {
-        //
-    })->create();
+    ->withExceptions(function (Exceptions $exceptions): void {})->create();

--- a/laravel-api/composer.json
+++ b/laravel-api/composer.json
@@ -3,11 +3,15 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
+    "keywords": [
+        "laravel",
+        "framework"
+    ],
     "license": "MIT",
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.2",
         "laravel/tinker": "^2.10.1"
     },
     "require-dev": {

--- a/laravel-api/composer.lock
+++ b/laravel-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c514d8f7b9fc5970bdd94287905ef584",
+    "content-hash": "8f387a0734f3bf879214e4aa2fca6e2f",
     "packages": [
         {
             "name": "brick/math",
@@ -1330,6 +1330,70 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.6"
             },
             "time": "2025-07-07T14:17:42+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "reference": "fd6df4f79f48a72992e8d29a9c0ee25422a0d677",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0",
+                "illuminate/database": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2025-07-09T19:45:24+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/laravel-api/config/app.php
+++ b/laravel-api/config/app.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Application Name
@@ -101,7 +100,7 @@ return [
 
     'previous_keys' => [
         ...array_filter(
-            explode(',', (string) env('APP_PREVIOUS_KEYS', ''))
+            explode(',', (string) env('APP_PREVIOUS_KEYS', '')),
         ),
     ],
 
@@ -122,5 +121,4 @@ return [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
-
 ];

--- a/laravel-api/config/auth.php
+++ b/laravel-api/config/auth.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Authentication Defaults
@@ -111,5 +110,4 @@ return [
     */
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
-
 ];

--- a/laravel-api/config/cache.php
+++ b/laravel-api/config/cache.php
@@ -3,7 +3,6 @@
 use Illuminate\Support\Str;
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Cache Store
@@ -32,7 +31,6 @@ return [
     */
 
     'stores' => [
-
         'array' => [
             'driver' => 'array',
             'serialize' => false,
@@ -89,7 +87,6 @@ return [
         'octane' => [
             'driver' => 'octane',
         ],
-
     ],
 
     /*
@@ -103,6 +100,5 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-cache-'),
-
+    'prefix' => env('CACHE_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')) . '-cache-'),
 ];

--- a/laravel-api/config/cors.php
+++ b/laravel-api/config/cors.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'allowed_methods' => ['*'],
+    'allowed_origins' => ['http://localhost:3000'], // Next.js 開発サーバー
+    'allowed_origins_patterns' => [],
+    'allowed_headers' => ['*'],
+    'exposed_headers' => [],
+    'max_age' => 0,
+    'supports_credentials' => true,
+];

--- a/laravel-api/config/database.php
+++ b/laravel-api/config/database.php
@@ -3,7 +3,6 @@
 use Illuminate\Support\Str;
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Database Connection Name
@@ -30,7 +29,6 @@ return [
     */
 
     'connections' => [
-
         'sqlite' => [
             'driver' => 'sqlite',
             'url' => env('DB_URL'),
@@ -112,7 +110,6 @@ return [
             // 'encrypt' => env('DB_ENCRYPT', 'yes'),
             // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
         ],
-
     ],
 
     /*
@@ -143,12 +140,11 @@ return [
     */
 
     'redis' => [
-
         'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-database-'),
+            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')) . '-database-'),
             'persistent' => env('REDIS_PERSISTENT', false),
         ],
 
@@ -177,7 +173,5 @@ return [
             'backoff_base' => env('REDIS_BACKOFF_BASE', 100),
             'backoff_cap' => env('REDIS_BACKOFF_CAP', 1000),
         ],
-
     ],
-
 ];

--- a/laravel-api/config/filesystems.php
+++ b/laravel-api/config/filesystems.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Filesystem Disk
@@ -29,7 +28,6 @@ return [
     */
 
     'disks' => [
-
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app/private'),
@@ -41,7 +39,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
             'throw' => false,
             'report' => false,
@@ -59,7 +57,6 @@ return [
             'throw' => false,
             'report' => false,
         ],
-
     ],
 
     /*
@@ -76,5 +73,4 @@ return [
     'links' => [
         public_path('storage') => storage_path('app/public'),
     ],
-
 ];

--- a/laravel-api/config/logging.php
+++ b/laravel-api/config/logging.php
@@ -6,7 +6,6 @@ use Monolog\Handler\SyslogUdpHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Log Channel
@@ -51,7 +50,6 @@ return [
     */
 
     'channels' => [
-
         'stack' => [
             'driver' => 'stack',
             'channels' => explode(',', (string) env('LOG_STACK', 'single')),
@@ -89,7 +87,7 @@ return [
             'handler_with' => [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
-                'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
+                'connectionString' => 'tls://' . env('PAPERTRAIL_URL') . ':' . env('PAPERTRAIL_PORT'),
             ],
             'processors' => [PsrLogMessageProcessor::class],
         ],
@@ -126,7 +124,5 @@ return [
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],
-
     ],
-
 ];

--- a/laravel-api/config/mail.php
+++ b/laravel-api/config/mail.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Mailer
@@ -36,7 +35,6 @@ return [
     */
 
     'mailers' => [
-
         'smtp' => [
             'transport' => 'smtp',
             'scheme' => env('MAIL_SCHEME'),
@@ -96,7 +94,6 @@ return [
             ],
             'retry_after' => 60,
         ],
-
     ],
 
     /*
@@ -114,5 +111,4 @@ return [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
-
 ];

--- a/laravel-api/config/queue.php
+++ b/laravel-api/config/queue.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Queue Connection Name
@@ -29,7 +28,6 @@ return [
     */
 
     'connections' => [
-
         'sync' => [
             'driver' => 'sync',
         ],
@@ -71,7 +69,6 @@ return [
             'block_for' => null,
             'after_commit' => false,
         ],
-
     ],
 
     /*
@@ -108,5 +105,4 @@ return [
         'database' => env('DB_CONNECTION', 'sqlite'),
         'table' => 'failed_jobs',
     ],
-
 ];

--- a/laravel-api/config/sanctum.php
+++ b/laravel-api/config/sanctum.php
@@ -1,0 +1,82 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
+        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
+        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+    ],
+];

--- a/laravel-api/config/services.php
+++ b/laravel-api/config/services.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Third Party Services
@@ -34,5 +33,4 @@ return [
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
         ],
     ],
-
 ];

--- a/laravel-api/config/session.php
+++ b/laravel-api/config/session.php
@@ -3,7 +3,6 @@
 use Illuminate\Support\Str;
 
 return [
-
     /*
     |--------------------------------------------------------------------------
     | Default Session Driver
@@ -129,7 +128,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel')).'-session'
+        Str::slug(env('APP_NAME', 'laravel')) . '-session',
     ),
 
     /*
@@ -213,5 +212,4 @@ return [
     */
 
     'partitioned' => env('SESSION_PARTITIONED_COOKIE', false),
-
 ];

--- a/laravel-api/database/factories/UserFactory.php
+++ b/laravel-api/database/factories/UserFactory.php
@@ -11,9 +11,7 @@ use Illuminate\Support\Str;
  */
 class UserFactory extends Factory
 {
-    /**
-     * The current password being used by the factory.
-     */
+    /** The current password being used by the factory. */
     protected static ?string $password;
 
     /**

--- a/laravel-api/database/migrations/2025_09_14_192621_create_personal_access_tokens_table.php
+++ b/laravel-api/database/migrations/2025_09_14_192621_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/laravel-api/pint.json
+++ b/laravel-api/pint.json
@@ -1,0 +1,330 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "array_indentation": true,
+        "array_syntax": {
+            "syntax": "short"
+        },
+        "binary_operator_spaces": {
+            "default": "single_space",
+            "operators": {
+                "=>": "single_space",
+                "=": "single_space"
+            }
+        },
+        "blank_line_after_namespace": true,
+        "blank_line_after_opening_tag": true,
+        "blank_line_before_statement": {
+            "statements": [
+                "return",
+                "throw",
+                "try"
+            ]
+        },
+        "cast_spaces": {
+            "space": "single"
+        },
+        "class_attributes_separation": {
+            "elements": {
+                "const": "one",
+                "method": "one",
+                "property": "one"
+            }
+        },
+        "concat_space": {
+            "spacing": "one"
+        },
+        "declare_parentheses": true,
+        "declare_strict_types": false,
+        "explicit_string_variable": true,
+        "final_class": false,
+        "fully_qualified_strict_types": true,
+        "global_namespace_import": {
+            "import_classes": true,
+            "import_constants": true,
+            "import_functions": true
+        },
+        "increment_style": {
+            "style": "post"
+        },
+        "is_null": false,
+        "lambda_not_used_import": true,
+        "linebreak_after_opening_tag": true,
+        "method_argument_space": {
+            "on_multiline": "ensure_fully_multiline",
+            "keep_multiple_spaces_after_comma": false
+        },
+        "method_chaining_indentation": true,
+        "modernize_types_casting": true,
+        "multiline_comment_opening_closing": true,
+        "multiline_whitespace_before_semicolons": {
+            "strategy": "no_multi_line"
+        },
+        "no_alias_language_construct_call": true,
+        "no_blank_lines_after_class_opening": true,
+        "no_blank_lines_after_phpdoc": true,
+        "no_empty_comment": true,
+        "no_empty_phpdoc": true,
+        "no_empty_statement": true,
+        "no_extra_blank_lines": {
+            "tokens": [
+                "attribute",
+                "break",
+                "case",
+                "continue",
+                "curly_brace_block",
+                "default",
+                "extra",
+                "parenthesis_brace_block",
+                "return",
+                "square_brace_block",
+                "switch",
+                "throw",
+                "use"
+            ]
+        },
+        "no_leading_namespace_whitespace": true,
+        "no_multiline_whitespace_around_double_arrow": true,
+        "no_multiple_statements_per_line": true,
+        "no_short_bool_cast": true,
+        "no_singleline_whitespace_before_semicolons": true,
+        "no_spaces_around_offset": {
+            "positions": [
+                "inside",
+                "outside"
+            ]
+        },
+        "no_superfluous_elseif": true,
+        "no_superfluous_phpdoc_tags": {
+            "allow_mixed": true,
+            "allow_unused_params": false,
+            "remove_inheritdoc": true
+        },
+        "no_trailing_comma_in_singleline": true,
+        "no_unneeded_control_parentheses": {
+            "statements": [
+                "break",
+                "clone",
+                "continue",
+                "echo_print",
+                "negative_instanceof",
+                "others",
+                "return",
+                "switch_case",
+                "yield",
+                "yield_from"
+            ]
+        },
+        "no_unneeded_curly_braces": {
+            "namespaces": true
+        },
+        "no_unneeded_import_alias": true,
+        "no_unset_cast": true,
+        "no_unused_imports": true,
+        "no_useless_else": true,
+        "no_useless_return": true,
+        "no_whitespace_before_comma_in_array": {
+            "after_heredoc": false
+        },
+        "not_operator_with_successor_space": false,
+        "nullable_type_declaration_for_default_null_value": true,
+        "object_operator_without_whitespace": true,
+        "operator_linebreak": {
+            "position": "beginning",
+            "only_booleans": true
+        },
+        "ordered_class_elements": {
+            "order": [
+                "use_trait",
+                "case",
+                "constant",
+                "constant_public",
+                "constant_protected",
+                "constant_private",
+                "property_public",
+                "property_protected",
+                "property_private",
+                "construct",
+                "destruct",
+                "magic",
+                "phpunit",
+                "method_public",
+                "method_protected",
+                "method_private"
+            ],
+            "sort_algorithm": "none"
+        },
+        "ordered_imports": {
+            "imports_order": [
+                "class",
+                "function",
+                "const"
+            ],
+            "sort_algorithm": "alpha"
+        },
+        "ordered_interfaces": true,
+        "ordered_traits": true,
+        "phpdoc_add_missing_param_annotation": {
+            "only_untyped": false
+        },
+        "phpdoc_align": {
+            "align": "vertical",
+            "tags": [
+                "method",
+                "param",
+                "property",
+                "property-read",
+                "property-write",
+                "return",
+                "throws",
+                "type",
+                "var"
+            ]
+        },
+        "phpdoc_annotation_without_dot": false,
+        "phpdoc_indent": true,
+        "phpdoc_inline_tag_normalizer": true,
+        "phpdoc_line_span": {
+            "const": "single",
+            "property": "single",
+            "method": "multi"
+        },
+        "phpdoc_no_access": true,
+        "phpdoc_no_empty_return": false,
+        "phpdoc_no_package": true,
+        "phpdoc_no_useless_inheritdoc": true,
+        "phpdoc_order": {
+            "order": [
+                "param",
+                "return",
+                "throws"
+            ]
+        },
+        "phpdoc_order_by_value": true,
+        "phpdoc_return_self_reference": true,
+        "phpdoc_scalar": true,
+        "phpdoc_separation": {
+            "groups": [
+                [
+                    "deprecated",
+                    "link",
+                    "see",
+                    "since"
+                ],
+                [
+                    "author",
+                    "copyright",
+                    "license"
+                ],
+                [
+                    "category",
+                    "package",
+                    "subpackage"
+                ],
+                [
+                    "property",
+                    "property-read",
+                    "property-write"
+                ],
+                [
+                    "param",
+                    "return"
+                ]
+            ]
+        },
+        "phpdoc_single_line_var_spacing": true,
+        "phpdoc_summary": false,
+        "phpdoc_tag_type": {
+            "tags": {
+                "inheritDoc": "inline"
+            }
+        },
+        "phpdoc_to_comment": {
+            "ignored_tags": [
+                "var"
+            ]
+        },
+        "phpdoc_trim": true,
+        "phpdoc_trim_consecutive_blank_line_separation": true,
+        "phpdoc_types": true,
+        "phpdoc_types_order": {
+            "null_adjustment": "always_last",
+            "sort_algorithm": "none"
+        },
+        "phpdoc_var_annotation_correct_order": true,
+        "phpdoc_var_without_name": true,
+        "protected_to_private": false,
+        "return_assignment": true,
+        "return_type_declaration": {
+            "space_before": "none"
+        },
+        "self_static_accessor": true,
+        "semicolon_after_instruction": true,
+        "short_scalar_cast": true,
+        "simple_to_complex_string_variable": true,
+        "simplified_if_return": true,
+        "simplified_null_return": false,
+        "single_blank_line_at_eof": true,
+        "single_class_element_per_statement": {
+            "elements": [
+                "const",
+                "property"
+            ]
+        },
+        "single_import_per_statement": {
+            "group_to_single_imports": false
+        },
+        "single_line_after_imports": true,
+        "single_line_comment_spacing": true,
+        "single_line_comment_style": {
+            "comment_types": [
+                "hash"
+            ]
+        },
+        "single_line_throw": false,
+        "single_quote": true,
+        "single_space_around_construct": true,
+        "single_trait_insert_per_statement": true,
+        "space_after_semicolon": {
+            "remove_in_empty_for_expressions": true
+        },
+        "standardize_not_equals": true,
+        "statement_indentation": true,
+        "switch_case_semicolon_to_colon": true,
+        "switch_case_space": true,
+        "switch_continue_to_break": true,
+        "ternary_operator_spaces": true,
+        "ternary_to_null_coalescing": true,
+        "trailing_comma_in_multiline": {
+            "after_heredoc": true,
+            "elements": [
+                "arguments",
+                "arrays",
+                "match",
+                "parameters"
+            ]
+        },
+        "trim_array_spaces": true,
+        "types_spaces": {
+            "space": "none"
+        },
+        "unary_operator_spaces": true,
+        "use_arrow_functions": true,
+        "visibility_required": {
+            "elements": [
+                "const",
+                "method",
+                "property"
+            ]
+        },
+        "void_return": false,
+        "whitespace_after_comma_in_array": {
+            "ensure_single_space": true
+        },
+        "yoda_style": {
+            "equal": false,
+            "identical": false,
+            "less_and_greater": false
+        }
+    }
+}

--- a/laravel-api/public/index.php
+++ b/laravel-api/public/index.php
@@ -6,15 +6,15 @@ use Illuminate\Http\Request;
 define('LARAVEL_START', microtime(true));
 
 // Determine if the application is in maintenance mode...
-if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
+if (file_exists($maintenance = __DIR__ . '/../storage/framework/maintenance.php')) {
     require $maintenance;
 }
 
 // Register the Composer autoloader...
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 // Bootstrap Laravel and handle the request...
 /** @var Application $app */
-$app = require_once __DIR__.'/../bootstrap/app.php';
+$app = require_once __DIR__ . '/../bootstrap/app.php';
 
 $app->handleRequest(Request::capture());

--- a/laravel-api/routes/api.php
+++ b/laravel-api/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\Api\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth:sanctum')->get('/me', [AuthController::class, 'me']);

--- a/laravel-api/routes/web.php
+++ b/laravel-api/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Http\Controllers\Api\AuthController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::middleware('guest')->post('/login', [AuthController::class, 'login']);
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);

--- a/laravel-api/tests/TestCase.php
+++ b/laravel-api/tests/TestCase.php
@@ -4,7 +4,4 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
-abstract class TestCase extends BaseTestCase
-{
-    //
-}
+abstract class TestCase extends BaseTestCase {}


### PR DESCRIPTION
## 📝 概要
Laravel SanctumによるSPA認証システムとコードフォーマッター設定を追加しました。

## ✨ 主な変更点

### 認証システム
- **Laravel Sanctum**を使用したセッションベース認証
- 以下のエンドポイントを実装：
  - `POST /login` - ログイン
  - `POST /logout` - ログアウト  
  - `GET /api/me` - 認証済みユーザー情報取得
  - `GET /sanctum/csrf-cookie` - CSRFトークン取得

### コードフォーマッター設定
- **Laravel Pint**設定（Laravelプリセット、シンプルスタイル）
- **EditorConfig**更新（PHP、JS、JSON用設定追加）
- **VSCode設定**（保存時自動フォーマット）
- **Prettier設定**（JS/CSS用、PHPは除外）
- **PHP CS Fixer**設定（代替オプション）

### Docker環境改善
- Apache DocumentRootを`/var/www/html/public`に修正
- Sanctum用環境変数追加
- ポートマッピング修正（8000:80）

## ✅ 動作確認済み
curlコマンドでの動作確認完了：
- [x] XSRF-TOKENとlaravel_sessionクッキーの設定
- [x] ログイン成功（ユーザー情報返却）
- [x] 認証済みAPIアクセス（Refererヘッダー必須）

## 📌 注意事項
- Sanctum認証にはRefererヘッダーが必要です（CSRF対策）
- フロントエンドは`http://localhost:3000`からのアクセスを想定

## 🧪 テスト方法
```bash
# 1. CSRF cookie取得
curl -X GET http://localhost:8000/sanctum/csrf-cookie -c cookies.txt -I

# 2. ログイン（要XSRF-TOKEN）
curl -X POST http://localhost:8000/login \
  -H "X-XSRF-TOKEN: {token}" \
  -b cookies.txt -c cookies.txt \
  -d '{"email":"test@example.com","password":"password123"}'

# 3. 認証済みAPI
curl -X GET http://localhost:8000/api/me \
  -H "Referer: http://localhost:8000" \
  -b cookies.txt
```

🤖 Generated with [Claude Code](https://claude.ai/code)