### PR TITLE
feat: TerraformでAWSインフラ構築を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ cookiejar
 # Code formatter cache
 laravel-api/.php-cs-fixer.cache
 *.cache
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+!terraform.tfvars.example

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,186 @@
+# Terraform Infrastructure as Code
+
+このディレクトリには、DevlogrプロジェクトのAWSインフラストラクチャを定義するTerraform設定が含まれています。
+
+## ディレクトリ構造
+
+```
+terraform/
+├── modules/              # 再利用可能なモジュール
+│   ├── networking/       # VPC、サブネット、セキュリティグループ
+│   ├── database/         # RDS MySQL
+│   └── compute/          # EC2インスタンス
+├── environments/         # 環境別設定
+│   └── dev/              # 開発環境
+│       ├── main.tf       # メイン設定ファイル
+│       ├── variables.tf  # 変数定義
+│       ├── outputs.tf    # 出力値定義
+│       └── terraform.tfvars.example  # 変数値の例
+├── versions.tf           # Terraformとプロバイダーのバージョン指定
+├── backend.tf            # バックエンド設定（初期はローカル）
+└── README.md             # このファイル
+```
+
+## 前提条件
+
+1. **AWSアカウント**: AWSアカウントを持っていること
+2. **AWS CLI**: インストール済みで認証情報が設定されていること
+
+   ```bash
+   aws configure
+   ```
+
+3. **Terraform**: バージョン1.6以上がインストールされていること
+
+   ```bash
+   terraform version
+   ```
+
+## セットアップ手順
+
+### 1. 変数ファイルの作成
+
+`terraform/environments/dev/terraform.tfvars.example` をコピーして `terraform.tfvars` を作成：
+
+```bash
+cd terraform/environments/dev
+cp terraform.tfvars.example terraform.tfvars
+```
+
+### 2. 変数の設定
+
+`terraform.tfvars` を編集して、以下の値を設定：
+
+- `key_pair_name`: EC2に接続するためのキーペア名（事前にAWSコンソールで作成）
+- `db_password`: RDSのマスターパスワード（強力なパスワードを設定）
+- `app_key`: Laravelアプリケーションキー（`php artisan key:generate --show`で生成）
+
+**重要**: `terraform.tfvars` は機密情報を含むため、Gitにコミットしないでください。
+
+### 3. EC2キーペアの作成
+
+AWSコンソールまたはAWS CLIでキーペアを作成：
+
+```bash
+aws ec2 create-key-pair --key-name devlogr-dev-key --query 'KeyMaterial' --output text > ~/.ssh/devlogr-dev-key.pem
+chmod 400 ~/.ssh/devlogr-dev-key.pem
+```
+
+### 4. Laravelアプリケーションキーの生成
+
+ローカル環境でLaravelアプリケーションキーを生成：
+
+```bash
+cd laravel-api
+php artisan key:generate --show
+```
+
+出力されたキーを `terraform.tfvars` の `app_key` に設定。
+
+### 5. Terraformの初期化
+
+```bash
+cd terraform/environments/dev
+terraform init
+```
+
+### 6. 実行計画の確認
+
+```bash
+terraform plan
+```
+
+### 7. インフラの作成
+
+```bash
+terraform apply
+```
+
+確認プロンプトで `yes` と入力すると、リソースが作成されます。
+
+### 8. 出力値の確認
+
+作成後、以下のコマンドで出力値を確認：
+
+```bash
+terraform output
+```
+
+## リソースの削除
+
+テスト後、リソースを削除してコストを抑える：
+
+```bash
+terraform destroy
+```
+
+## モジュールの説明
+
+### Networking Module
+
+- VPC (10.0.0.0/16)
+- パブリックサブネット (10.0.1.0/24, 10.0.2.0/24) - 2つのAZ
+- プライベートサブネット (10.0.11.0/24, 10.0.12.0/24) - 2つのAZ
+- Internet Gateway
+- セキュリティグループ（EC2用、RDS用）
+
+### Database Module
+
+- RDS MySQL 8.0
+- インスタンスクラス: db.t2.micro（無料枠）
+- ストレージ: 20GB (gp2)
+- バックアップ: 7日間保持
+- プライベートサブネットに配置
+
+### Compute Module
+
+- EC2インスタンス
+- インスタンスタイプ: t2.micro（無料枠）
+- AMI: Amazon Linux 2023
+- User DataスクリプトでLaravel環境を自動構築
+- パブリックサブネットに配置
+
+## 注意事項
+
+1. **コスト**: 無料枠を超えるとコストが発生します。テスト後は必ず `terraform destroy` でリソースを削除してください。
+
+2. **セキュリティ**:
+   - `terraform.tfvars` はGitにコミットしないでください
+   - 本番環境では、より厳格なセキュリティ設定を適用してください
+
+3. **状態管理**: 初期はローカルバックエンドを使用しています。チーム開発や本番環境では、S3バックエンドへの移行を検討してください。
+
+4. **データベース接続**: RDSはプライベートサブネットに配置されているため、EC2インスタンスからのみアクセス可能です。
+
+## トラブルシューティング
+
+### EC2に接続できない
+
+1. セキュリティグループでSSH（ポート22）が許可されているか確認
+2. キーペアが正しく設定されているか確認
+3. EC2インスタンスのパブリックIPを確認
+
+### データベースに接続できない
+
+1. RDSセキュリティグループでEC2セキュリティグループからの3306ポートが許可されているか確認
+2. RDSがプライベートサブネットに配置されているか確認
+3. データベースのエンドポイントと認証情報を確認
+
+### User Dataスクリプトが実行されない
+
+1. EC2インスタンスのログを確認：
+
+   ```bash
+   ssh -i ~/.ssh/your-key.pem ec2-user@<public-ip>
+   sudo cat /var/log/user-data.log
+   ```
+
+2. 手動でスクリプトを実行してエラーを確認
+
+## 次のステップ
+
+- [ ] S3バックエンドへの移行
+- [ ] ALB（Application Load Balancer）の追加
+- [ ] Auto Scaling Groupの追加
+- [ ] CloudWatch監視の設定
+- [ ] 本番環境（prod）の追加

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,13 @@
+# 初期はローカルバックエンドを使用
+# 動作確認後、S3バックエンドに移行する場合は以下のコメントを解除して設定
+#
+# terraform {
+#   backend "s3" {
+#     bucket         = "devlogr-terraform-state"
+#     key            = "dev/terraform.tfstate"
+#     region         = "ap-northeast-1"
+#     encrypt        = true
+#     dynamodb_table = "terraform-state-lock"
+#   }
+# }
+

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# 利用可能なAZを取得
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# Networking Module
+module "networking" {
+  source = "../../modules/networking"
+
+  vpc_cidr            = "10.0.0.0/16"
+  availability_zones  = slice(data.aws_availability_zones.available.names, 0, 2)
+  environment         = var.environment
+  project_name        = var.project_name
+  public_subnet_cidrs = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+}
+
+# Database Module
+module "database" {
+  source = "../../modules/database"
+
+  environment          = var.environment
+  project_name         = var.project_name
+  private_subnet_ids   = module.networking.private_subnet_ids
+  security_group_id    = module.networking.rds_security_group_id
+  db_instance_class    = "db.t2.micro"
+  db_allocated_storage = 20
+  db_engine_version    = "8.0"
+  db_name              = "devlogr"
+  db_username          = var.db_username
+  db_password          = var.db_password
+  backup_retention_period = 7
+  skip_final_snapshot    = true
+}
+
+# Compute Module
+module "compute" {
+  source = "../../modules/compute"
+
+  environment       = var.environment
+  project_name      = var.project_name
+  public_subnet_id  = module.networking.public_subnet_ids[0]
+  security_group_id = module.networking.ec2_security_group_id
+  instance_type     = "t2.micro"
+  key_pair_name     = var.key_pair_name
+  db_host           = module.database.db_instance_address
+  db_name           = module.database.db_name
+  db_username       = var.db_username
+  db_password       = var.db_password
+  app_url           = var.app_url  # EC2作成後に手動で更新するか、後で修正
+  github_repo_url   = var.github_repo_url
+  app_key           = var.app_key
+
+  depends_on = [module.database]
+}
+

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -1,0 +1,46 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.networking.vpc_id
+}
+
+output "ec2_public_ip" {
+  description = "EC2 instance public IP address"
+  value       = module.compute.instance_public_ip
+}
+
+output "ec2_public_dns" {
+  description = "EC2 instance public DNS name"
+  value       = module.compute.instance_public_dns
+}
+
+output "rds_endpoint" {
+  description = "RDS instance endpoint"
+  value       = module.database.db_instance_endpoint
+}
+
+output "rds_address" {
+  description = "RDS instance address"
+  value       = module.database.db_instance_address
+}
+
+output "application_url" {
+  description = "Application URL (update this after EC2 is created)"
+  value       = "http://${module.compute.instance_public_ip}"
+}
+
+output "ssh_command" {
+  description = "SSH command to connect to EC2 instance"
+  value       = "ssh -i ~/.ssh/${var.key_pair_name}.pem ec2-user@${module.compute.instance_public_ip}"
+}
+
+output "database_connection_info" {
+  description = "Database connection information"
+  value = {
+    host     = module.database.db_instance_address
+    port     = module.database.db_instance_port
+    database = module.database.db_name
+    username = module.database.db_instance_username
+  }
+  sensitive = true
+}
+

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,26 @@
+# AWS設定
+aws_region = "ap-northeast-1"
+
+# 環境設定
+environment  = "dev"
+project_name = "devlogr"
+
+# データベース設定
+db_username = "admin"
+# db_password は環境変数または terraform.tfvars で設定（Gitにコミットしない）
+# db_password = "your-secure-password-here"
+
+# EC2設定
+key_pair_name = "your-key-pair-name"
+
+# Laravel設定
+# app_key は環境変数または terraform.tfvars で設定（Gitにコミットしない）
+# app_key を生成するには: php artisan key:generate --show
+# app_key = "base64:..."
+
+# アプリケーションURL（EC2作成後に自動的に設定される）
+app_url = "http://ec2-instance"
+
+# GitHubリポジトリ（オプション: 自動デプロイする場合）
+# github_repo_url = "https://github.com/your-username/devlogr.git"
+

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,53 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "devlogr"
+}
+
+variable "db_password" {
+  description = "RDS master password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_username" {
+  description = "RDS master username"
+  type        = string
+  default     = "admin"
+}
+
+variable "key_pair_name" {
+  description = "EC2 Key Pair name"
+  type        = string
+}
+
+variable "app_key" {
+  description = "Laravel application key (generate with: php artisan key:generate --show)"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_repo_url" {
+  description = "GitHub repository URL (optional, leave empty for manual setup)"
+  type        = string
+  default     = ""
+}
+
+variable "app_url" {
+  description = "Application URL (will be set to EC2 public IP after creation)"
+  type        = string
+  default     = "http://ec2-instance"
+}
+

--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -1,0 +1,61 @@
+# Data source for latest Amazon Linux 2023 AMI
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# EC2 Instance
+resource "aws_instance" "main" {
+  ami                    = var.ami_id != "" ? var.ami_id : data.aws_ami.amazon_linux.id
+  instance_type          = var.instance_type
+  key_name               = var.key_pair_name
+  subnet_id              = var.public_subnet_id
+  vpc_security_group_ids = [var.security_group_id]
+
+  user_data = base64encode(templatefile("${path.module}/user_data.sh", {
+    environment     = var.environment
+    db_host         = var.db_host
+    db_name         = var.db_name
+    db_username     = var.db_username
+    db_password     = var.db_password
+    app_url         = var.app_url
+    github_repo_url = var.github_repo_url != "" ? var.github_repo_url : ""
+    app_key         = var.app_key
+  }))
+
+  # Root volume
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+    encrypted   = false
+  }
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-ec2"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Elastic IP (オプション: 固定IPが必要な場合)
+# resource "aws_eip" "main" {
+#   instance = aws_instance.main.id
+#   domain   = "vpc"
+#
+#   tags = {
+#     Name        = "${var.project_name}-${var.environment}-eip"
+#     Environment = var.environment
+#     Project     = var.project_name
+#   }
+# }
+

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -1,0 +1,25 @@
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.main.id
+}
+
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.main.public_ip
+}
+
+output "instance_private_ip" {
+  description = "Private IP address of the EC2 instance"
+  value       = aws_instance.main.private_ip
+}
+
+output "instance_public_dns" {
+  description = "Public DNS name of the EC2 instance"
+  value       = aws_instance.main.public_dns
+}
+
+# output "elastic_ip" {
+#   description = "Elastic IP address (if enabled)"
+#   value       = try(aws_eip.main.public_ip, null)
+# }
+

--- a/terraform/modules/compute/user_data.sh
+++ b/terraform/modules/compute/user_data.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e
+
+# ログ出力用
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+echo "Starting user-data script at $(date)"
+
+# システム更新
+yum update -y
+
+# PHP 8.3 + Apache + 必要な拡張機能のインストール
+amazon-linux-extras enable php8.3
+yum install -y \
+    php \
+    php-cli \
+    php-common \
+    php-mysqlnd \
+    php-pdo \
+    php-xml \
+    php-mbstring \
+    php-json \
+    php-curl \
+    php-zip \
+    php-gd \
+    httpd \
+    git \
+    unzip
+
+# Apache起動と自動起動設定
+systemctl start httpd
+systemctl enable httpd
+
+# Composerインストール
+curl -sS https://getcomposer.org/installer | php
+mv composer.phar /usr/local/bin/composer
+chmod +x /usr/local/bin/composer
+
+# Apache DocumentRootを設定
+sed -i 's|DocumentRoot "/var/www/html"|DocumentRoot "/var/www/html/laravel-api/public"|g' /etc/httpd/conf/httpd.conf
+
+# Apache設定: AllowOverride All
+sed -i '/<Directory "\/var\/www\/html">/,/<\/Directory>/s/AllowOverride None/AllowOverride All/' /etc/httpd/conf/httpd.conf
+
+# アプリケーションディレクトリ作成
+mkdir -p /var/www/html
+cd /var/www/html
+
+# GitHubからクローン（リポジトリURLが指定されている場合）
+if [ -n "$github_repo_url" ]; then
+    git clone "$github_repo_url" .
+else
+    # ローカル開発用: ディレクトリ構造を作成
+    mkdir -p laravel-api
+    cd laravel-api
+fi
+
+# Laravel環境変数設定
+cat > .env <<EOF
+APP_NAME=Devlogr
+APP_ENV=$environment
+APP_KEY=$app_key
+APP_DEBUG=true
+APP_URL=$app_url
+
+DB_CONNECTION=mysql
+DB_HOST=$db_host
+DB_PORT=3306
+DB_DATABASE=$db_name
+DB_USERNAME=$db_username
+DB_PASSWORD=$db_password
+
+SESSION_DRIVER=database
+SESSION_LIFETIME=120
+SESSION_DOMAIN=localhost
+
+SANCTUM_STATEFUL_DOMAINS=localhost
+EOF
+
+# Composer依存関係インストール
+if [ -f composer.json ]; then
+    composer install --no-dev --optimize-autoloader
+fi
+
+# ストレージとキャッシュのパーミッション設定
+chown -R apache:apache /var/www/html
+chmod -R 755 /var/www/html/laravel-api/storage
+chmod -R 755 /var/www/html/laravel-api/bootstrap/cache
+
+# マイグレーション実行（DB接続が確立されるまで待機）
+echo "Waiting for database connection..."
+sleep 30
+
+# マイグレーション実行
+cd /var/www/html/laravel-api
+php artisan migrate --force || echo "Migration failed, but continuing..."
+
+# Apache再起動
+systemctl restart httpd
+
+echo "User-data script completed at $(date)"
+

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -1,0 +1,77 @@
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "devlogr"
+}
+
+variable "public_subnet_id" {
+  description = "Public subnet ID for EC2"
+  type        = string
+}
+
+variable "security_group_id" {
+  description = "Security group ID for EC2"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instance (if not provided, will use latest Amazon Linux 2023)"
+  type        = string
+  default     = ""
+}
+
+variable "key_pair_name" {
+  description = "Name of the EC2 Key Pair"
+  type        = string
+}
+
+variable "db_host" {
+  description = "RDS database host"
+  type        = string
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "devlogr"
+}
+
+variable "db_username" {
+  description = "Database username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Database password"
+  type        = string
+  sensitive   = true
+}
+
+variable "app_url" {
+  description = "Application URL"
+  type        = string
+}
+
+variable "github_repo_url" {
+  description = "GitHub repository URL for cloning the application"
+  type        = string
+  default     = ""
+}
+
+variable "app_key" {
+  description = "Laravel application key (should be generated)"
+  type        = string
+  sensitive   = true
+}
+

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -1,0 +1,58 @@
+# DB Subnet Group
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-${var.environment}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-db-subnet-group"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# RDS MySQL Instance
+resource "aws_db_instance" "main" {
+  identifier             = "${var.project_name}-${var.environment}-mysql"
+  engine                 = "mysql"
+  engine_version         = var.db_engine_version
+  instance_class         = var.db_instance_class
+  allocated_storage     = var.db_allocated_storage
+  storage_type           = "gp2"
+  db_name                = var.db_name
+  username               = var.db_username
+  password               = var.db_password
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.security_group_id]
+
+  # Backup settings
+  backup_retention_period = var.backup_retention_period
+  backup_window          = "03:00-04:00"
+  maintenance_window     = "mon:04:00-mon:05:00"
+
+  # Performance Insights (無料枠)
+  performance_insights_enabled = false
+
+  # Monitoring
+  monitoring_interval = 0
+  monitoring_role_arn = null
+
+  # Deletion protection (dev環境では無効)
+  deletion_protection = false
+  skip_final_snapshot = var.skip_final_snapshot
+
+  # Storage encryption
+  storage_encrypted = false
+
+  # Public access (プライベートサブネットに配置するため無効)
+  publicly_accessible = false
+
+  # Multi-AZ (dev環境では無効、コスト削減)
+  multi_az = false
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-mysql"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -1,0 +1,31 @@
+output "db_instance_id" {
+  description = "RDS instance ID"
+  value       = aws_db_instance.main.id
+}
+
+output "db_instance_endpoint" {
+  description = "RDS instance endpoint"
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_instance_address" {
+  description = "RDS instance address"
+  value       = aws_db_instance.main.address
+}
+
+output "db_instance_port" {
+  description = "RDS instance port"
+  value       = aws_db_instance.main.port
+}
+
+output "db_instance_username" {
+  description = "RDS instance master username"
+  value       = aws_db_instance.main.username
+  sensitive   = true
+}
+
+output "db_name" {
+  description = "Database name"
+  value       = aws_db_instance.main.db_name
+}
+

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -1,0 +1,69 @@
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "devlogr"
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for RDS"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group ID for RDS"
+  type        = string
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t2.micro"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage for RDS (GB)"
+  type        = number
+  default     = 20
+}
+
+variable "db_engine_version" {
+  description = "MySQL engine version"
+  type        = string
+  default     = "8.0"
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "devlogr"
+}
+
+variable "db_username" {
+  description = "Database master username"
+  type        = string
+  default     = "admin"
+}
+
+variable "db_password" {
+  description = "Database master password (should be provided via environment variable)"
+  type        = string
+  sensitive   = true
+}
+
+variable "backup_retention_period" {
+  description = "Backup retention period (days)"
+  type        = number
+  default     = 7
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot on deletion (for dev environment)"
+  type        = bool
+  default     = true
+}
+

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,152 @@
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-vpc"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-igw"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-public-subnet-${count.index + 1}"
+    Environment = var.environment
+    Project     = var.project_name
+    Type        = "public"
+  }
+}
+
+# Private Subnets
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-private-subnet-${count.index + 1}"
+    Environment = var.environment
+    Project     = var.project_name
+    Type        = "private"
+  }
+}
+
+# Route Table for Public Subnets
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-public-rt"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Route Table Associations for Public Subnets
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# Security Group for EC2
+resource "aws_security_group" "ec2" {
+  name        = "${var.project_name}-${var.environment}-ec2-sg"
+  description = "Security group for EC2 instances"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-ec2-sg"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+
+# Security Group for RDS
+resource "aws_security_group" "rds" {
+  name        = "${var.project_name}-${var.environment}-rds-sg"
+  description = "Security group for RDS instances"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "MySQL"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-rds-sg"
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}
+

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,0 +1,30 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "ID of the Internet Gateway"
+  value       = aws_internet_gateway.main.id
+}
+
+output "ec2_security_group_id" {
+  description = "ID of the EC2 security group"
+  value       = aws_security_group.ec2.id
+}
+
+output "rds_security_group_id" {
+  description = "ID of the RDS security group"
+  value       = aws_security_group.rds.id
+}
+

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -1,0 +1,34 @@
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+  default     = "devlogr"
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
+}
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+


### PR DESCRIPTION
## 概要
Terraformを使用してAWSインフラストラクチャを構築するための設定を追加しました。

## 変更内容
- **Networkingモジュール**: VPC、パブリック/プライベートサブネット、Internet Gateway、セキュリティグループ
- **Databaseモジュール**: RDS MySQL 8.0（無料枠対応）
- **Computeモジュール**: EC2インスタンス（Amazon Linux 2023）とLaravel環境構築用User Dataスクリプト
- **Dev環境設定**: 全モジュールを統合した開発環境用設定
- **ドキュメント**: セットアップ手順と使用方法をREADMEに追加

## 技術スタック
- Terraform 1.6+
- AWS Provider 5.0+
- Amazon Linux 2023
- PHP 8.3 + Apache + MySQL 8.0

## セットアップ
```bash
cd terraform/environments/dev
cp terraform.tfvars.example terraform.tfvars
# 必要な変数を設定
terraform init
terraform plan
terraform apply
```

## 注意事項
- 無料枠（t2.micro、db.t2.micro）を使用
- テスト後は`terraform destroy`でリソースを削除してください
- `terraform.tfvars`は機密情報を含むためGitにコミットしないでください